### PR TITLE
Fix error: Werror=reorder

### DIFF
--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -5,12 +5,12 @@
 #include "StateMachine.h"
 
 StateMachine::StateMachine()
-: _currentState(nullptr)
-, _errorHandler(nullptr)
-, _previousState(nullptr)
-, _errorState(nullptr)
-, _transitioningInProgress(false)
-, _currentEventIndex(0)
+    : _currentState(nullptr)
+    , _previousState(nullptr)
+    , _errorState(nullptr)
+    , _currentEventIndex(0)
+    , _errorHandler(nullptr)
+    , _transitioningInProgress(false)
 {
     reset();
 }


### PR DESCRIPTION
This pull request fixes the following compilation error:

```
In file included from c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.cpp:5:
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.h: In constructor 'StateMachine::StateMachine()':
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.h:46:18: error: 'StateMachine::_errorHandler' will be initialized after [-Werror=reorder]
     ErrorHandler _errorHandler;
                  ^~~~~~~~~~~~~
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.h:42:12: error:   'State* StateMachine::_previousState' [-Werror=reorder]
     State* _previousState;
            ^~~~~~~~~~~~~~
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.cpp:7:1: error:   when initialized here [-Werror=reorder]
 StateMachine::StateMachine()
 ^~~~~~~~~~~~
In file included from c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.cpp:5:
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.h:47:10: error: 'StateMachine::_transitioningInProgress' will be initialized after [-Werror=reorder]
     bool _transitioningInProgress;
          ^~~~~~~~~~~~~~~~~~~~~~~~
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.h:45:9: error:   'int StateMachine::_currentEventIndex' [-Werror=reorder]
     int _currentEventIndex;
         ^~~~~~~~~~~~~~~~~~
c:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster\src\StateMachine.cpp:7:1: error:   when initialized here [-Werror=reorder]
 StateMachine::StateMachine()
 ^~~~~~~~~~~~
cc1plus.exe: some warnings being treated as errors
Multiple libraries were found for "State.h"
  Used: C:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster
  Not used: C:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster_fork
Using library Seeed_Arduino_MIDIMaster at version 0.1 in folder: C:\Users\%USERNAME%\Documents\Arduino\libraries\Seeed_Arduino_MIDIMaster 
exit status 1

Compilation error: exit status 1
```